### PR TITLE
Prevent renaming file facade nested classes incorrectly

### DIFF
--- a/src/main/java/proguard/kotlin/printer/Context.java
+++ b/src/main/java/proguard/kotlin/printer/Context.java
@@ -102,7 +102,11 @@ implements   KotlinTypeParameterVisitor
             }
             else if (kotlinMetadata.k == METADATA_KIND_FILE_FACADE)
             {
-                result = result.replaceFirst("^" + contextItem.clazz.getName() + ".", "");
+                String fileFacadeClazzName = contextItem.clazz.getName();
+                if (className.startsWith(fileFacadeClazzName + "$"))
+                {
+                    result = result.replace(fileFacadeClazzName + "$", "");
+                }
             }
         }
 


### PR DESCRIPTION
Avoid renaming the classes when the outer file facade class doesn't end with a $ symbol.
